### PR TITLE
Thread specification in lines 103-105 of hifisomatic.wdl overrides corresponding inputs in json config

### DIFF
--- a/hifisomatic.wdl
+++ b/hifisomatic.wdl
@@ -100,9 +100,9 @@ workflow hifisomatic {
         patient_normal_bam_files = patient_normal_bam_files,
         ref_fasta = ref_to_use,
         ref_fasta_index = ref_fasta_index,
-        pbmm2_threads = 32,
-        merge_bam_threads = 8,
-        samtools_threads = 8,
+        pbmm2_threads = pbmm2_threads,
+        merge_bam_threads = merge_bam_threads,
+        samtools_threads = samtools_threads,
         skip_align = skip_align,
         strip_kinetics = strip_kinetics
     }


### PR DESCRIPTION
 I think the specification of specific thread values for pbmm2, bam merging, and samtools on lines 103-105 of hifisomatic.wdl is overriding whatever the user provides for the corresponding values in the input json files.

I think the lines should be changed from

```
pbmm2_threads = 32,  
merge_bam_threads = 8,
samtools_threads = 8,
```
to
```
pbmm2_threads = pbmm2_threads,  
merge_bam_threads = merge_bam_threads,
samtools_threads = samtools_threads,
```

and when I make these changes locally the corresponding commands specify the correct number of threads.  

Thanks for the great set of tools/workflow!