### PR TITLE
Update visualize_hifisomatic.qmd

### DIFF
--- a/containers/somatic_r_tools/visualize_hifisomatic.qmd
+++ b/containers/somatic_r_tools/visualize_hifisomatic.qmd
@@ -645,7 +645,7 @@ col_with_onlyNA <- apply(
     table_to_disp[, rest_of_cols],
     2,
     function(x) {
-        all(x == ".")
+        all(x %in% c(".",NA))
     }
 )
 col_with_onlyNA <- names(col_with_onlyNA[col_with_onlyNA == TRUE])


### PR DESCRIPTION
# Problem
Had a case where the "PS" column was `NA` rather than TRUE or FALSE after the `all(x == ".")` function. Having an `NA` rather than a T/F value caused subsequent steps to fail.

This occurred because the filtered `table_to_display` had a PS column with only `NA` values. Thus, when filtering for names that only equals TRUE...this column was retained, but the column name was not properly pulled leading to a value of `NA` in the "col_with_onlyNA" vector...which is not a valid column name for the next filtering step below. 

`select(!all_of(col_with_onlyNA))`

# Solution
Modify the `all(x==".")` function to also look for columns that are only `NA`
`all(x %in% c(".",NA))`
